### PR TITLE
修复u-collapse-item组件的body高度无法跟随content变化

### DIFF
--- a/uview-ui/components/u-collapse-item/u-collapse-item.vue
+++ b/uview-ui/components/u-collapse-item/u-collapse-item.vue
@@ -15,7 +15,7 @@
 			<slot v-else name="title-all" />
 		</view>
 		<view class="u-collapse-body" :style="[{
-				height: isShow ? height + 'px' : '0'
+				height: isShow ? 'auto' : '0'
 			}]">
 			<view class="u-collapse-content" :id="elId" :style="[bodyStyle]">
 				<slot></slot>


### PR DESCRIPTION
u-collapse-item组件的body为固定高度，当其content高度为可变（如可折叠、展开）时会出现不一致