### PR TITLE
【修复】u-avatar组件设置img-mode无效

### DIFF
--- a/uview-ui/components/u-avatar/u-avatar.vue
+++ b/uview-ui/components/u-avatar/u-avatar.vue
@@ -6,7 +6,7 @@
 			class="u-avatar__img"
 			v-if="!uText && avatar"
 			:src="avatar" 
-			:mode="mode"
+			:mode="imgMode"
 		></image>
 		<text class="u-line-1" v-else-if="uText" :style="{
 			fontSize: '38rpx'


### PR DESCRIPTION
u-avatar组件中使用`img-mode`时发现无效，原`u-avatar`的`mode`主要都在处理样式，而`imgMode`没有使用。