### PR TITLE
修复thStyle样式无效

### DIFF
--- a/uview-ui/components/u-th/u-th.vue
+++ b/uview-ui/components/u-th/u-th.vue
@@ -39,7 +39,7 @@
 				style.padding = this.parent.padding;
 				style.borderBottom = `solid 1px ${this.parent.borderColor}`;
 				style.borderRight = `solid 1px ${this.parent.borderColor}`;
-				Object.assign(style, this.parent.style);
+				Object.assign(style, this.parent.thStyle);
 				this.thStyle = style;
 			}
 		}


### PR DESCRIPTION
新版本的thStyle无效了， 因为父组件table并未将 thStyle绑定到style，所以子组件这里合并style 应该取父组件的thStyle参数而不是style