### PR TITLE
u-message-input 添加value初始值判断和 清除输入方法

### DIFF
--- a/uview-ui/components/u-message-input/u-message-input.vue
+++ b/uview-ui/components/u-message-input/u-message-input.vue
@@ -129,6 +129,9 @@
 			value: {
 				immediate: true,
 				handler(val) {
+					if(val===null){
+						val ="";
+					}
 					// 转为字符串
 					val = String(val);
 					// 超出部分截掉
@@ -174,6 +177,9 @@
 				if (String(value).length == this.maxlength) {
 					this.$emit('finish', value);
 				}
+			},
+			clear(){
+				this.valueModel="";
 			}
 		}
 	}


### PR DESCRIPTION
`<u-message-input   :value="form.code" ></u-message-input>`
```js
data() {
			return {
				form:{
					email:'',
					code:null    // undefined
				}
                        }
      }
```

会出现显示  n u l l ，不符合设计。

![image](https://user-images.githubusercontent.com/27793729/130903663-aa17ea1e-a1f7-4400-8cb5-df19191a686b.png)


考虑需重新输入的场景，组件没有清除输入的功能，添加一个clear方法
`<u-message-input ref="msgInput" > </u-message-input>`
调用
`this.$refs.msgInput.clear();`

清空输入框
![image](https://user-images.githubusercontent.com/27793729/130903541-77dc762f-78d2-47f5-8947-61876b4df9c1.png)

