### PR TITLE
fix: 修复u-image组件的src属性, 先传入空值再传入非空值时,无法触发loading效果的bug

### DIFF
--- a/uview-ui/components/u-image/u-image.vue
+++ b/uview-ui/components/u-image/u-image.vue
@@ -172,6 +172,7 @@ export default {
 					this.loading = false;
 				} else {
 					this.isError = false;
+          this.loading = true;
 				}
 			}
 		}

--- a/uview-ui/components/u-image/u-image.vue
+++ b/uview-ui/components/u-image/u-image.vue
@@ -172,7 +172,7 @@ export default {
 					this.loading = false;
 				} else {
 					this.isError = false;
-          this.loading = true;
+					this.loading = true;
 				}
 			}
 		}


### PR DESCRIPTION
在开发过程中, 动态获取src前, src初始值一般为空字符串
u-image组件实例化之后, src为空会error
动态请求src的XHR返回后, src变为图片路径字符串, isError变为true, 但无法触发loading图片, 只能白图直至图片加载完成