### PR TITLE
fix: 修复部分代码注释里英文单词拼写错误的问题

### DIFF
--- a/uview-ui/libs/function/guid.js
+++ b/uview-ui/libs/function/guid.js
@@ -6,7 +6,7 @@
  * v-for的时候,推荐使用后端返回的id而不是循环的index
  * @param {Number} len uuid的长度
  * @param {Boolean} firstU 将返回的首字母置为"u"
- * @param {Nubmer} radix 生成uuid的基数(意味着返回的字符串都是这个基数),2-二进制,8-八进制,10-十进制,16-十六进制
+ * @param {Number} radix 生成uuid的基数(意味着返回的字符串都是这个基数),2-二进制,8-八进制,10-十进制,16-十六进制
  */
 function guid(len = 32, firstU = true, radix = null) {
 	let chars = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz'.split('');
@@ -29,7 +29,7 @@ function guid(len = 32, firstU = true, radix = null) {
 			}
 		}
 	}
-	// 移除第一个字符,并用u替代,因为第一个字符为数值时,该guuid不能用作id或者class
+	// 移除第一个字符,并用u替代,因为第一个字符为数值时,该guid不能用作id或者class
 	if (firstU) {
 		uuid.shift();
 		return 'u' + uuid.join('');

--- a/uview-ui/libs/mixin/mixin.js
+++ b/uview-ui/libs/mixin/mixin.js
@@ -48,7 +48,7 @@ module.exports = {
 		uni.$emit('uOnReachBottom')
 	},
 	beforeDestroy() {
-		// 判断当前页面是否存在parent和chldren，一般在checkbox和checkbox-group父子联动的场景会有此情况
+		// 判断当前页面是否存在parent和children，一般在checkbox和checkbox-group父子联动的场景会有此情况
 		// 组件销毁时，移除子组件在父组件children数组中的实例，释放资源，避免数据混乱
 		if(this.parent && uni.$u.test.array(this.parent.children)) {
 			// 组件销毁时，移除父组件中的children数组中对应的实例

--- a/uview-ui/libs/util/async-validator.js
+++ b/uview-ui/libs/util/async-validator.js
@@ -437,7 +437,7 @@ function range(rule, value, source, errors, options) {
 	}
 
 	if (str) {
-		// 处理码点大于U+010000的文字length属性不准确的bug，如"𠮷𠮷𠮷".lenght !== 3
+		// 处理码点大于U+010000的文字length属性不准确的bug，如"𠮷𠮷𠮷".length !== 3
 		val = value.replace(spRegexp, '_').length;
 	}
 


### PR DESCRIPTION
在学习/使用 uView 的过程中，阅读源码的时候发现一些注释里有单词拼写错误的问题
故花了些时间去检查下其他的文件有没有类似的情况并去更正了它