### PR TITLE
fix: 修复如果http请求响应过快而造成的uniApp警告showLoading需配对使用问题

### DIFF
--- a/uview-ui/libs/request/index.js
+++ b/uview-ui/libs/request/index.js
@@ -28,8 +28,8 @@ class Request {
 
 		return new Promise((resolve, reject) => {
 			options.complete = (response) => {
-				// 请求返回后，隐藏loading(如果请求返回快的话，可能会没有loading)
-				uni.hideLoading();
+				// 如果请求在loadingTime时间以外才响应，才需要隐藏loading(如果请求返回快的话，可能会没有loading)
+				this.config.showLoading && !this.config.timer && uni.hideLoading();
 				// 清除定时器，如果请求回来了，就无需loading
 				clearTimeout(this.config.timer);
 				this.config.timer = null;


### PR DESCRIPTION
当http请求在设定的loadingTime内返回结果的话，
源代码此时没有调用定时器中的uni.showLoading()，
但在request响应中依然调用了uni.hideLoading(),由此造成的警告如下图。
![image](https://user-images.githubusercontent.com/55353369/135396135-415c030a-0860-4589-9d39-346a3070f2d6.png)

**repair_plan：在响应函数中做一下hideLoading的判断即可**