### PR TITLE
修改upload组件单词拼写错误导致终止上传失效，及进度条100后隐藏

### DIFF
--- a/uview-ui/components/u-upload/u-upload.vue
+++ b/uview-ui/components/u-upload/u-upload.vue
@@ -21,7 +21,7 @@
 				<u-icon class="u-icon" :name="delIcon" size="20" :color="delColor"></u-icon>
 			</view>
 			<u-line-progress
-				v-if="showProgress && item.progress > 0 && !item.error"
+				v-if="showProgress && item.progress > 0 && item.progress !=100 && !item.error"
 				:show-percent="false"
 				height="16"
 				class="u-progress"
@@ -498,7 +498,7 @@ export default {
 		// 执行移除图片的动作，上方代码只是判断是否可以移除
 		handlerDeleteItem(index) {
 			// 如果文件正在上传中，终止上传任务，进度在0 < progress < 100则意味着正在上传
-			if (this.lists[index].process < 100 && this.lists[index].process > 0) {
+			if (this.lists[index].progress < 100 && this.lists[index].progress > 0) {
 				typeof this.lists[index].uploadTask != 'undefined' && this.lists[index].uploadTask.abort();
 			}
 			this.lists.splice(index, 1);

--- a/uview-ui/components/u-upload/u-upload.vue
+++ b/uview-ui/components/u-upload/u-upload.vue
@@ -21,7 +21,7 @@
 				<u-icon class="u-icon" :name="delIcon" size="20" :color="delColor"></u-icon>
 			</view>
 			<u-line-progress
-				v-if="showProgress && item.progress > 0 && item.progress !=100 && !item.error"
+				v-if="showProgress && item.progress > 0 && item.progress != 100 && !item.error"
 				:show-percent="false"
 				height="16"
 				class="u-progress"


### PR DESCRIPTION
- `handlerDeleteItem`方法中应为`progress`而不是`process`
- 进度条到达100时应该隐藏掉