### PR TITLE
解决显示和实际选择的值不一致的问题

### DIFF
--- a/uview-ui/components/u-select/u-select.vue
+++ b/uview-ui/components/u-select/u-select.vue
@@ -36,7 +36,7 @@
 					</view>
 				</view>
 				<view class="u-select__body">
-					<picker-view @change="columnChange" class="u-select__body__picker-view" :value="defaultSelector" @pickstart="pickstart" @pickend="pickend">
+					<picker-view @change="columnChange" class="u-select__body__picker-view" :value="defaultSelector" @pickstart="pickstart" @pickend="pickend" v-if="value">
 						<picker-view-column v-for="(item, index) in columnData" :key="index">
 							<view class="u-select__body__picker-view__item" v-for="(item1, index1) in item" :key="index1">
 								<view class="u-line-1">{{ item1[labelName] }}</view>


### PR DESCRIPTION
由于uni-app组件picker-view的bug，:value="defaultSelector"的值为[0]时没有更新显示