### PR TITLE
修复select组件在小程序端展示选值的bug，修复步进器设置可输入小数在小程序真机上无法输入的问题

### DIFF
--- a/uview-ui/components/u-number-box/u-number-box.vue
+++ b/uview-ui/components/u-number-box/u-number-box.vue
@@ -10,7 +10,7 @@
 		</view>
 		<input :disabled="disabledInput || disabled" :cursor-spacing="getCursorSpacing" :class="{ 'u-input-disabled': disabled }"
 		    v-model="inputVal" class="u-number-input" @blur="onBlur" @focus="onFocus"
-		    type="number" :style="{
+		    :type="positiveInteger?'number':'digit'" :style="{
 				color: color,
 				fontSize: size + 'rpx',
 				background: bgColor,

--- a/uview-ui/components/u-select/u-select.vue
+++ b/uview-ui/components/u-select/u-select.vue
@@ -278,12 +278,13 @@ export default {
 			let columnIndex = e.detail.value;
 			// 由于后面是需要push进数组的，所以需要先清空数组
 			this.selectValue = [];
+			this.defaultSelector = columnIndex;
 			if(this.mode == 'mutil-column-auto') {
 				// 对比前后两个数组，寻找变更的是哪一列，如果某一个元素不同，即可判定该列发生了变化
 				this.lastSelectIndex.map((val, idx) => {
 					if (val != columnIndex[idx]) index = idx;
 				});
-				this.defaultSelector = columnIndex;
+				
 				for (let i = index + 1; i < this.columnNum; i++) {
 					// 当前变化列的下一列的数据，需要获取上一列的数据，同时需要指定是上一列的第几个的children，再往后的
 					// 默认是队列的第一个为默认选项


### PR DESCRIPTION
select组件：在小程序的表现bug为：首次选择了b值，再次打开默认选中值为b，点击选择却拿到了a值
步进器组件：当设置为可输入小数时，在小程序真机键盘上并无小数点，input number类型在小程序端表现差异