### PR TITLE
修复可以选择给定范围之外当天的日期

### DIFF
--- a/uview-ui/components/u-calendar/u-calendar.vue
+++ b/uview-ui/components/u-calendar/u-calendar.vue
@@ -289,13 +289,9 @@
 			init() {
 				let now = new Date();
 				let minDate = new Date(this.minDate);
-				if (now < minDate) {
-					now = minDate;
-				}
 				let maxDate = new Date(this.maxDate);
-				if (now > maxDate) {
-					now = maxDate;
-				}
+				if (now < minDate) now = minDate;
+				if (now > maxDate) now = maxDate;
 				this.year = now.getFullYear();
 				this.month = now.getMonth() + 1;
 				this.day = now.getDate();

--- a/uview-ui/components/u-calendar/u-calendar.vue
+++ b/uview-ui/components/u-calendar/u-calendar.vue
@@ -288,6 +288,14 @@
 			},
 			init() {
 				let now = new Date();
+				let minDate = new Date(this.minDate);
+				if (now < minDate) {
+					now = minDate;
+				}
+				let maxDate = new Date(this.maxDate);
+				if (now > maxDate) {
+					now = maxDate;
+				}
 				this.year = now.getFullYear();
 				this.month = now.getMonth() + 1;
 				this.day = now.getDate();


### PR DESCRIPTION
在单个日期模式下，如果当天日期在最大日期和最小日期之外。由于默认选中当天日期，点击确定会直接选中当天日期。
![3](https://user-images.githubusercontent.com/48768539/147847800-a2349b5c-3227-4b03-ac3a-b90e3ed8f7f5.png)
![1](https://user-images.githubusercontent.com/48768539/147847806-37385069-745f-4aa1-be32-49d1a4a63b15.png)
![2](https://user-images.githubusercontent.com/48768539/147847808-1dc0d473-9c57-40b2-99ba-166a7e51e1f9.png)
