### PR TITLE
fix(tabs): amend ClassName spelling mistake

### DIFF
--- a/uview-ui/components/u-tabs/u-tabs.vue
+++ b/uview-ui/components/u-tabs/u-tabs.vue
@@ -5,7 +5,7 @@
 		<!-- $u.getRect()对组件根节点无效，因为写了.in(this)，故这里获取内层接点尺寸 -->
 		<view>
 			<scroll-view scroll-x class="u-scroll-view" :scroll-left="scrollLeft" scroll-with-animation>
-				<view class="u-scroll-box" :id="id" :class="{'u-tabs-scorll-flex': !isScroll}">
+				<view class="u-scroll-box" :id="id" :class="{'u-tabs-scroll-flex': !isScroll}">
 					<view class="u-tab-item u-line-1" :id="'u-tab-item-' + index" v-for="(item, index) in list" :key="index" @tap="clickTab(index)"
 					 :style="[tabItemStyle(index)]">
 						<u-badge :count="item[count] || item['count'] || 0" :offset="offset" size="mini"></u-badge>
@@ -362,7 +362,7 @@
 		bottom: 0;
 	}
 
-	.u-tabs-scorll-flex {
+	.u-tabs-scroll-flex {
 		@include vue-flex;
 		justify-content: space-between;
 	}


### PR DESCRIPTION
修复Tabs中的className的命名拼写错误