### PR TITLE
fix:修复deepMerge函数当`source`对象中存在属性值为`null`或`undefined`时，`source[prop]`找不到`concat`属性的问题

### DIFF
--- a/uview-ui/libs/function/deepMerge.js
+++ b/uview-ui/libs/function/deepMerge.js
@@ -13,6 +13,10 @@ function deepMerge(target = {}, source = {}) {
 				if (typeof source[prop] !== 'object') {
 					target[prop] = source[prop];
 				} else {
+					if(source[prop] === null || source[prop] === undefined){
+						target[prop] = target[prop];
+						continue;
+					}
 					if (target[prop].concat && source[prop].concat) {
 						target[prop] = target[prop].concat(source[prop]);
 					} else {


### PR DESCRIPTION
修复deepMerge函数当`source`对象中存在属性值为`null`或`undefined`时，`source[prop]`找不到`concat`属性的问题
#965 