### PR TITLE
   把block改为template

### DIFF
--- a/uview-ui/components/u-line-progress/u-line-progress.vue
+++ b/uview-ui/components/u-line-progress/u-line-progress.vue
@@ -10,9 +10,9 @@
 			striped && stripedActive ? 'u-striped-active' : ''
 		]" class="u-active" :style="[progressStyle]">
 			<slot v-if="$slots.default || $slots.$default" />
-			<block v-else-if="showPercent">
+			<template v-else-if="showPercent">
 				{{percent + '%'}}
-			</block>
+			</template>
 		</view>
 	</view>
 </template>
@@ -102,7 +102,7 @@
 
 <style lang="scss" scoped>
 	@import "../../libs/css/style.components.scss";
-	
+
 	.u-progress {
 		overflow: hidden;
 		height: 15px;


### PR DESCRIPTION
https://uniapp.dcloud.net.cn/tutorial/page.html#template-block  <template/> 和 <block/> 并不是一个组件，它们仅仅是一个包装元素，不会在页面中做任何渲染，只接受控制属性。<block/> 在不同的平台表现存在一定差异，推荐统一使用 <template/>。