### PR TITLE
修复页面跳转前后this指向不一致的问题

### DIFF
--- a/uview-ui/libs/mixin/mixin.js
+++ b/uview-ui/libs/mixin/mixin.js
@@ -10,10 +10,11 @@ module.exports = {
 		// 查询节点信息
 		// 目前此方法在支付宝小程序中无法获取组件跟接点的尺寸，为支付宝的bug(2020-07-21)
 		// 解决办法为在组件根部再套一个没有任何作用的view元素
-		$uGetRect(selector, all) {
+		// 修复页面跳转前后this指向不一致的问题
+		$uGetRect(selector, all, that) {
 			return new Promise(resolve => {
 				uni.createSelectorQuery().
-				in(this)[all ? 'selectAll' : 'select'](selector)
+				in(that?that:this)[all ? 'selectAll' : 'select'](selector)
 					.boundingClientRect(rect => {
 						if (all && Array.isArray(rect) && rect.length) {
 							resolve(rect)


### PR DESCRIPTION
$uGetRect this指向错误

### 期望的结果是什么?
当页面跳转之后，在返回原页面，正常获取节点布局信息

### 实际的结果是什么?
当页面跳转之后，在返回原页面，this指向已经发生改变，无法获取节点布局信息

###修复方法
应该在原页面调用api时传入this，同时SuGetRect做出以下改动:

```
$uGetRect(selector, all, that) {
  return new Promise(resolve => {
    uni.createSelectorQuery().
    in(that?that:this)[all ? 'selectAll' : 'select'](selector)
    .boundingClientRect(rect => {
      if (all && Array.isArray(rect) && rect.length) {
        resolve(rect)
      }
      if (!all && rect) {
        resolve(rect)
    }).exec()
  })
}
```

功能即可正常