### PR TITLE
u-select==> setColumnNum， children数组长度为0时，组件会报错

### DIFF
--- a/uview-ui/components/u-select/u-select.vue
+++ b/uview-ui/components/u-select/u-select.vue
@@ -225,7 +225,7 @@ export default {
 				let num = 1;
 				let column = this.list;
 				// 只要有元素并且第一个元素有children属性，继续历遍
-				while(column[0][this.childName]) {
+				while(column[0][this.childName].length>0) {
 					column = column[0] ? column[0][this.childName] : {};
 					num ++;
 				}


### PR DESCRIPTION
实际开发遇到的问题，有时地区数据的最里层也会有 children ，但是这个 children 的长度为0，组件会报错。

解决方法：1、循环删除空的 children。
                  2、在u-select组件的setColumnNum方法，while循环处加了判断children的长度。

我用第二种方法解决的。

期望：更新组件。这样遇到这个问题的人就不需要找到问题并使用第一种方法或第二种方法解决，更能提高大家效率。