### PR TITLE
添加标签属性

### DIFF
--- a/uview-ui/components/u-count-down/u-count-down.vue
+++ b/uview-ui/components/u-count-down/u-count-down.vue
@@ -10,7 +10,7 @@
 			:style="{fontSize: separatorSize + 'rpx', color: separatorColor, paddingBottom: separator == 'colon' ? '4rpx' : 0}"
 			v-if="showDays && (hideZeroDay || (!hideZeroDay && d != '00'))"
 		>
-			{{ separator == 'colon' ? ':' : '天' }}
+			{{ separator == 'colon' ? ':' : dayLabel }}
 		</view>
 		<view class="u-countdown-item" :style="[itemStyle]" v-if="showHours">
 			<view class="u-countdown-time" :style="{ fontSize: fontSize + 'rpx', color: color}">
@@ -22,7 +22,7 @@
 			:style="{fontSize: separatorSize + 'rpx', color: separatorColor, paddingBottom: separator == 'colon' ? '4rpx' : 0}"
 			v-if="showHours"
 		>
-			{{ separator == 'colon' ? ':' : '时' }}
+			{{ separator == 'colon' ? ':' : hourLabel }}
 		</view>
 		<view class="u-countdown-item" :style="[itemStyle]" v-if="showMinutes">
 			<view class="u-countdown-time" :style="{ fontSize: fontSize + 'rpx', color: color}">
@@ -34,7 +34,7 @@
 			:style="{fontSize: separatorSize + 'rpx', color: separatorColor, paddingBottom: separator == 'colon' ? '4rpx' : 0}"
 			v-if="showMinutes"
 		>
-			{{ separator == 'colon' ? ':' : '分' }}
+			{{ separator == 'colon' ? ':' : minuteLabel }}
 		</view>
 		<view class="u-countdown-item" :style="[itemStyle]" v-if="showSeconds">
 			<view class="u-countdown-time" :style="{ fontSize: fontSize + 'rpx', color: color}">
@@ -46,7 +46,7 @@
 			:style="{fontSize: separatorSize + 'rpx', color: separatorColor, paddingBottom: separator == 'colon' ? '4rpx' : 0}"
 			v-if="showSeconds && separator == 'zh'"
 		>
-			秒
+			{{ secondLabel }}
 		</view>
 	</view>
 </template>
@@ -158,6 +158,26 @@ export default {
 		hideZeroDay: {
 			type: Boolean,
 			default: false
+		},
+		// 天的单位
+		dayLabel: {
+			type: String,
+			default: "天",
+		},
+		// 小时的单位
+		hourLabel: {
+			type: String,
+			default: "时"
+		},
+		// 分钟的单位
+		minuteLabel: {
+			type: String,
+			default: "分"
+		},
+		// 秒的单位
+		secondLabel: {
+			type: String,
+			default: "秒"
 		}
 	},
 	watch: {


### PR DESCRIPTION
为倒计时组件添加时间单位标签

本次提交为 u-count-down.vue 组件添加了四个新的属性，允许用户自定义倒计时中不同时间单位的标签。新属性如下：

- dayLabel：天的标签
- hourLabel：小时的标签
- minuteLabel：分钟的标签
- secondLabel：秒的标签

每个属性都是字符串类型，有一个默认值，与组件当前的行为相匹配。用户可以覆盖这些默认值，以显示其首选语言或格式的标签。

新属性在组件的模板中使用，替换了之前使用的硬编码标签。组件的行为和样式仍然与之前相同。

此更改应使组件更灵活，更易于在不同的上下文中使用。请审核并让我知道您是否有任何反馈或建议。